### PR TITLE
Adjusts seed messages to be verbose

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -29,7 +29,7 @@ CSV.foreach('db/data/olympic_data_2016.csv', headers: true) do |data|
       )
     end
   rescue
-    puts olympian.error
+    puts olympian.errors.messages
   end
 
   begin
@@ -44,7 +44,7 @@ CSV.foreach('db/data/olympic_data_2016.csv', headers: true) do |data|
         olympian.events << event
     end
   rescue
-    puts event.error
+    puts event.errors.messages
   end
 
   begin
@@ -55,6 +55,6 @@ CSV.foreach('db/data/olympic_data_2016.csv', headers: true) do |data|
       medal.medal = nil
     end
   rescue
-    puts medal.error
+    puts medal.errors.messages
   end
 end


### PR DESCRIPTION
## What functionality does this accomplish?
This is trouble shooting seeding data
For some reason it is not accepting on heroku when it was working previously as well as on local

**Description:**
Adds errors.messages call to olympians to see what the error might be
